### PR TITLE
Default to using SUDO_USER rather than `logname`

### DIFF
--- a/packer
+++ b/packer
@@ -36,9 +36,16 @@ def package_installed(module, pkg):
   rc, stdout, stderr = module.run_command('pacman -Q %s' % pkg, check_rc=False)
   return rc == 0
 
-def logname(module):
-  rc, stdout, stderr = module.run_command('logname', check_rc=True)
-  return stdout
+def get_sudo_user(module):
+  # ansible sets the SUDO_USER environment variable.  Default to using this,
+  # calling `logname` if SUDO_USER is by some chance empty.
+  sudo_user = os.environ.get('SUDO_USER')
+
+  if not sudo_user:
+    rc, stdout, stderr = module.run_command('logname', check_rc=True)
+    sudo_user = stdout
+
+  return sudo_user
 
 def check_packages(module, pkgs, state):
   would_be_changed = []
@@ -61,14 +68,14 @@ def check_packages(module, pkgs, state):
 def install_packages(module, pkgs):
   num_installed = 0
 
-  user = logname(module)
+  sudo_user = get_sudo_user(module)
   cmd = 'sudo -u %s packer --noconfirm --noedit -S %s'
 
   for pkg in pkgs:
     if package_installed(module, pkg):
       continue
 
-    rc, stdout, stderr = module.run_command(cmd % (user, pkg), check_rc=False)
+    rc, stdout, stderr = module.run_command(cmd % (sudo_user, pkg), check_rc=False)
 
     if rc != 0:
       module.fail_json(msg='failed to install package %s, because: %s' % (pkg,stderr))


### PR DESCRIPTION
When running the following task with `-c local` and `-e ansible_python_interpreter=/usr/bin/python2` on Arch Linux, kernel `3.18.1-1-chromebook`:

``` yaml
- name: install aur packages with packer
      packer:
        name: downgrade
        state: present
      become: yes
      tags:
        - packer
```

I receive this error message:

``` shell
failed: [localhost] => {"cmd": "logname", "failed": true, "rc": 1}
stderr: logname: no login name

msg: logname: no login name

FATAL: all hosts have already failed -- aborting
```

It looks like this is most likely a problem with my Bash environment (_see_, e.g., [this StackOverflow post](http://stackoverflow.com/questions/25078081/ssh-and-execute-any-command-returns-logname-no-login-name)), so that's on me :).  But, since `ansible` sets the `SUDO_USER` environment variable when running with `--become-method=sudo`, which can be used instead for the `sudo -u` commands in this module.  This PR implements relying on `SUDO_USER` by default, falling back to calling `logname` in case `SUDO_USER` is unset.
